### PR TITLE
Add dependabot config for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Creates update PRs similar to https://github.com/dbast/md-publisher/pulls with history for each dependency bump etc for review.